### PR TITLE
Add repository in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,10 @@
     "doc": "doc",
     "test": "tests"
   },
-  "repository": "",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/stefanpenner/ember-strict-resolver.git"
+  },
   "scripts": {
     "build": "ember build",
     "start": "ember server",


### PR DESCRIPTION
Filling repository in `package.json` will make it easier to get here from npmjs.com as well as from emberobserver.com