### PR TITLE
Add engine support

### DIFF
--- a/addon/index.js
+++ b/addon/index.js
@@ -44,6 +44,10 @@ export default class Resolver {
 
     if (name === 'main') {
       moduleName = `${prefix}/${type}`;
+    } else if (type === 'engine') {
+      moduleName = `${name}/engine`;
+    } else if (type === 'route-map') {
+      moduleName = `${name}/routes`;
     } else {
       moduleName = `${prefix}/${type}s/${name.replace(/\./g, '/')}`;
     }

--- a/addon/index.js
+++ b/addon/index.js
@@ -1,9 +1,11 @@
 import require from 'require';
 import Ember from 'ember';
 
+const { dasherize } = Ember.String;
+
 // disable the normalization cache as we no longer normalize, the cache has
 // become a bottle neck.
-Ember.Registry.prototype.normalize = function(i) { return i; }
+Ember.Registry.prototype.normalize = function (i) { return i; }
 
 export default class Resolver {
   constructor(attrs) {
@@ -17,7 +19,9 @@ export default class Resolver {
   }
 
   moduleNameForFullName(fullName) {
-    // TODO: development assertion or warning if not already normalized
+    Ember.assert(`Attempted to lookup "${fullName}". Use "${dasherize(fullName)}" instead.`,
+      !fullName.match(/[a-z]+[A-Z]+/));
+
     let prefix, type, name, moduleName;
 
     const fullNameParts = fullName.split('@');

--- a/tests/unit/strict-resolver/basic-test.js
+++ b/tests/unit/strict-resolver/basic-test.js
@@ -135,3 +135,67 @@ test("can lookup a view in another namespace with different syntax", function(as
   assert.ok(view, 'view was returned');
   assert.equal(view, expected, 'default export was returned');
 });
+
+test("can lookup a view", function(assert) {
+  assert.expect(3);
+
+  let expected = { isViewFactory: true };
+  define('dummy/views/queue-list', [], function(){
+    assert.ok(true, "view was invoked properly");
+
+    return { default: expected };
+  });
+
+  var view = resolver.resolve('view:queue-list');
+
+  assert.ok(view, 'view was returned');
+  assert.equal(view, expected, 'default export was returned');
+});
+
+test("can lookup a helper", function(assert) {
+  assert.expect(3);
+
+  let expected = { isHelperInstance: true };
+  define('dummy/helpers/reverse-list', [], function(){
+    assert.ok(true, "helper was invoked properly");
+
+    return { default: expected };
+  });
+
+  var helper = resolver.resolve('helper:reverse-list');
+
+  assert.ok(helper, 'helper was returned');
+  assert.equal(helper, expected, 'default export was returned');
+});
+
+test('can lookup an engine', function(assert) {
+  assert.expect(3);
+
+  let expected = {};
+  define('dummy/engine', [], function(){
+    assert.ok(true, 'engine was invoked properly');
+
+    return { default: expected };
+  });
+
+  let engine = resolver.resolve('engine:dummy');
+
+  assert.ok(engine, 'engine was returned');
+  assert.equal(engine, expected, 'default export was returned');
+});
+
+test('can lookup a route-map', function(assert) {
+  assert.expect(3);
+
+  let expected = { isRouteMap: true };
+  define('dummy/routes', [], function(){
+    assert.ok(true, 'route-map was invoked properly');
+
+    return { default: expected };
+  });
+
+  let routeMap = resolver.resolve('route-map:dummy');
+
+  assert.ok(routeMap, 'route-map was returned');
+  assert.equal(routeMap, expected, 'default export was returned');
+});

--- a/tests/unit/strict-resolver/basic-test.js
+++ b/tests/unit/strict-resolver/basic-test.js
@@ -1,7 +1,7 @@
 /* globals define, requirejs */
 
 import Ember from 'ember';
-import { module, test, skip } from 'ember-qunit';
+import { module, test } from 'ember-qunit';
 import Resolver from 'ember-strict-resolver';
 
 let originalRegistryEntries, originalEmberAssert, resolver;
@@ -169,29 +169,6 @@ test('warns if looking up a camelCase name', function(assert){
 
   var helper = resolver.resolve('helper:reverseList');
   assert.ok(!helper, 'no helper was returned');
-});
-
-skip('errors if lookup of a route-map does not specify isRouteMap', function(assert) {
-  assert.expect(2);
-
-  let expected = { isRouteMap: false };
-  define('foo-bar/routes', [], function(){
-    assert.ok(true, 'route-map was invoked properly');
-
-    return { default: expected };
-  });
-
-  assert.throws(() => {
-    resolver.resolve('route-map:foo-bar');
-  }, /The route map for foo-bar should be wrapped by 'buildRoutes' before exporting/);
-});
-
-skip("will return the raw value if no 'default' is available", function(assert) {
-  define('foo-bar/fruits/orange', [], function(){
-    return 'is awesome';
-  });
-
-  assert.equal(resolver.resolve('fruit:orange'), 'is awesome', 'adapter was returned');
 });
 
 test("will unwrap the 'default' export automatically", function(assert) {

--- a/tests/unit/strict-resolver/basic-test.js
+++ b/tests/unit/strict-resolver/basic-test.js
@@ -106,54 +106,6 @@ test("can lookup something in another namespace with different syntax", function
   assert.equal(adapter, expected, 'default export was returned');
 });
 
-test("can lookup a view in another namespace", function(assert) {
-  assert.expect(3);
-
-  let expected = { isViewFactory: true };
-  define('other/views/post', [], function(){
-    assert.ok(true, "view was invoked properly");
-
-    return { default: expected };
-  });
-
-  var view = resolver.resolve('other@view:post');
-
-  assert.ok(view, 'view was returned');
-  assert.equal(view, expected, 'default export was returned');
-});
-
-test("can lookup a view in another namespace with different syntax", function(assert) {
-  assert.expect(3);
-
-  let expected = { isViewFactory: true };
-  define('other/views/post', [], function(){
-    assert.ok(true, "view was invoked properly");
-
-    return { default: expected };
-  });
-
-  var view = resolver.resolve('view:other@post');
-
-  assert.ok(view, 'view was returned');
-  assert.equal(view, expected, 'default export was returned');
-});
-
-test("can lookup a view", function(assert) {
-  assert.expect(3);
-
-  let expected = { isViewFactory: true };
-  define('foo-bar/views/queue-list', [], function(){
-    assert.ok(true, "view was invoked properly");
-
-    return { default: expected };
-  });
-
-  var view = resolver.resolve('view:queue-list');
-
-  assert.ok(view, 'view was returned');
-  assert.equal(view, expected, 'default export was returned');
-});
-
 test("can lookup a helper", function(assert) {
   assert.expect(3);
 


### PR DESCRIPTION
There's a couple skipped tests in here right now. We should probably discuss if we want to support those features:
- errors if lookup of a route-map does not specify isRouteMap
- will return the raw value if no 'default' is available