### PR TITLE
remove side-effects running both resolvers in the same project

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,13 @@ in app/resolver.js
 export { default } from 'ember-strict-resolver';
 ```
 
+_For additional improvements when fully using the ember-strict-resolver monkey patching the registry to no longer cache and simply returning the values passed like the following can be produce extra performance._
+
+```js
+// disable the normalization cache as we no longer normalize, the cache has become a bottle neck.
+Ember.Registry.prototype.normalize = function (i) { return i; }
+```
+
 
 # Development of the addon
 

--- a/addon/index.js
+++ b/addon/index.js
@@ -11,10 +11,6 @@ export default class Resolver {
   }
 
   static create(args) {
-    // disable the normalization cache as we no longer normalize, the cache has
-    // become a bottle neck.
-    Ember.Registry.prototype.normalize = function (i) { return i; }
-
     return new this(args);
   }
 

--- a/addon/index.js
+++ b/addon/index.js
@@ -3,10 +3,6 @@ import Ember from 'ember';
 
 const { dasherize } = Ember.String;
 
-// disable the normalization cache as we no longer normalize, the cache has
-// become a bottle neck.
-Ember.Registry.prototype.normalize = function (i) { return i; }
-
 export default class Resolver {
   constructor(attrs) {
     if (attrs) {
@@ -15,6 +11,10 @@ export default class Resolver {
   }
 
   static create(args) {
+    // disable the normalization cache as we no longer normalize, the cache has
+    // become a bottle neck.
+    Ember.Registry.prototype.normalize = function (i) { return i; }
+
     return new this(args);
   }
 


### PR DESCRIPTION
In a project that I am working on, we are trying to incrementally  move to ember-strict-resolver but because of side effects this will not work.

```
import appConfig from './environment/config';
import Resolver from 'ember-resolver';
import StrictResolver from 'ember-strict-resolver';

export default (function lookupResolverMethod() {
  if (appConfig.emberStrictResolver) {
    return StrictResolver;
  }

  return Resolver;
})();
```

More specifically I think it is this code in classic decorators that requires the ember-resolver by default. https://github.com/emberjs/ember-classic-decorator/blob/35581575bbf66672099d5228651ae79f5b0e8f17/vendor/classic-decorator/index.js#L152