### PR TITLE
[bug] resolving environment config should work

### DIFF
--- a/addon/index.js
+++ b/addon/index.js
@@ -47,6 +47,8 @@ export default class Resolver {
       moduleName = `${name}/engine`;
     } else if (type === 'route-map') {
       moduleName = `${name}/routes`;
+    } else if (type === 'config') {
+      moduleName = `${prefix}/${type}/${name.replace(/\./g, '/')}`;
     } else {
       moduleName = `${prefix}/${type}s/${name.replace(/\./g, '/')}`;
     }

--- a/tests/unit/strict-resolver/basic-test.js
+++ b/tests/unit/strict-resolver/basic-test.js
@@ -45,7 +45,8 @@ module('Unit | strict-resolver | basic', function(hooks) {
       ['route:application', 'foo-bar/routes/application'],
       ['route:application/index', 'foo-bar/routes/application/index'],
       ['application:main', 'foo-bar/application'],
-      ['route:foo.bar.baz.index', 'foo-bar/routes/foo/bar/baz/index']
+      ['route:foo.bar.baz.index', 'foo-bar/routes/foo/bar/baz/index'],
+      ['config:environment', 'foo-bar/config/environment']
     ];
 
     assert.expect(testPairs.length);


### PR DESCRIPTION
fixes #22 

*Why?*

ember-a11y-testing uses resolveRegistration('config:environment'). This works in the ember-resolver/classic as there is a hard coded rule that says to not pluralize config. This adds a similar rule but in the form of a strict requirement rather than a part of a pluralize strategy like ember-resolver/classic.