### PR TITLE
[migration] allows developers to set a legacyMappings lookup map to help migrate from ember-resolver/classic to ember-resolver/strict

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,23 @@ _For additional improvements when fully using the ember-strict-resolver monkey p
 Ember.Registry.prototype.normalize = function (i) { return i; }
 ```
 
+## Migration
+
+Migrating away from use the _ember-resolver/classic_ can be done in piecemeal by supporting a sub-set of the old resolution formats.
+
+```js
+> _app/resolver.js_
+
+import StrictResolver from 'ember-strict-resolver';
+
+export StrictResolver.create({
+  failSet: {
+    'service:camelCaseNotSupported': 'service:camel-case-not-supported'
+  }
+})
+```
+
+This will allow you file PRs with libraries that currently do not support the strict resolver in its entirety.
 
 # Development of the addon
 

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Migrating away from use the _ember-resolver/classic_ can be done in piecemeal by
 import StrictResolver from 'ember-strict-resolver';
 
 export StrictResolver.create({
-  failSet: {
+  legacyMappings: {
     'service:camelCaseNotSupported': 'service:camel-case-not-supported'
   }
 })

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Ember.Registry.prototype.normalize = function (i) { return i; }
 Migrating away from use the _ember-resolver/classic_ can be done in piecemeal by supporting a sub-set of the old resolution formats.
 
 ```js
-> _app/resolver.js_
+// app/resolver.js
 
 import Resolver from 'ember-strict-resolver';
 

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ export default class extends Resolver {
   };
 
   resolve(_fullName) {
-    const fullName = this.legacyMappings[fullName] || fullName;
+    const fullName = this.legacyMappings[_fullName] || _fullName;
 
     return super.resolve(fullName);
   }

--- a/README.md
+++ b/README.md
@@ -30,13 +30,19 @@ Migrating away from use the _ember-resolver/classic_ can be done in piecemeal by
 ```js
 > _app/resolver.js_
 
-import StrictResolver from 'ember-strict-resolver';
+import Resolver from 'ember-strict-resolver';
 
-export StrictResolver.create({
-  legacyMappings: {
+export default class extends Resolver {
+  legacyMappings = {
     'service:camelCaseNotSupported': 'service:camel-case-not-supported'
+  };
+
+  resolve(_fullName) {
+    const fullName = this.legacyMappings[fullName] || fullName;
+
+    return super.resolve(fullName);
   }
-})
+}
 ```
 
 This will allow you file PRs with libraries that currently do not support the strict resolver in its entirety.

--- a/addon/index.js
+++ b/addon/index.js
@@ -5,13 +5,11 @@ import require from 'require';
 
 export default class Resolver {
   constructor(attrs) {
-    this.failSet = {};
-
     if (attrs) {
       this.namespace = attrs.namespace;
       // used as a static map from one format to annother
       // { 'service:somethingThatIsDashed', 'service:something-that-is-dashed' }
-      this.failSet = attrs.failSet || {};
+      this.legacyMappings = attrs.legacyMappings || {};
     }
   }
 
@@ -62,7 +60,7 @@ export default class Resolver {
   }
 
   resolve(fullName) {
-    const _fullName = this.failSet[fullName] || fullName;
+    const _fullName = this.legacyMappings && this.legacyMappings[fullName] || fullName;
     const moduleName = this.moduleNameForFullName(_fullName);
 
     if (require.has(moduleName)) {

--- a/addon/index.js
+++ b/addon/index.js
@@ -7,9 +7,6 @@ export default class Resolver {
   constructor(attrs) {
     if (attrs) {
       this.namespace = attrs.namespace;
-      // used as a static map from one format to annother
-      // { 'service:somethingThatIsDashed', 'service:something-that-is-dashed' }
-      this.legacyMappings = attrs.legacyMappings || {};
     }
   }
 
@@ -60,8 +57,7 @@ export default class Resolver {
   }
 
   resolve(fullName) {
-    const _fullName = this.legacyMappings && this.legacyMappings[fullName] || fullName;
-    const moduleName = this.moduleNameForFullName(_fullName);
+    const moduleName = this.moduleNameForFullName(fullName);
 
     if (require.has(moduleName)) {
       // hit

--- a/addon/index.js
+++ b/addon/index.js
@@ -5,8 +5,13 @@ import require from 'require';
 
 export default class Resolver {
   constructor(attrs) {
+    this.failSet = {};
+
     if (attrs) {
       this.namespace = attrs.namespace;
+      // used as a static map from one format to annother
+      // { 'service:somethingThatIsDashed', 'service:something-that-is-dashed' }
+      this.failSet = attrs.failSet || {};
     }
   }
 
@@ -57,7 +62,8 @@ export default class Resolver {
   }
 
   resolve(fullName) {
-    let moduleName = this.moduleNameForFullName(fullName);
+    const _fullName = this.failSet[fullName] || fullName;
+    const moduleName = this.moduleNameForFullName(_fullName);
 
     if (require.has(moduleName)) {
       // hit

--- a/tests/unit/strict-resolver/basic-test.js
+++ b/tests/unit/strict-resolver/basic-test.js
@@ -58,10 +58,10 @@ module('Unit | strict-resolver | basic', function(hooks) {
     })
   });
 
-  test('can lookup via failSet for migrating off of ember-resolver/classic', function(assert){
+  test('can lookup via legacyMappings for migrating off of ember-resolver/classic', function(assert){
     assert.expect(2);
 
-    setupResolver({ failSet: { 'service:somethingThatIsDashed': 'service:something-that-is-dashed' }, namespace: { modulePrefix: 'foo-bar' } })
+    setupResolver({ legacyMappings: { 'service:somethingThatIsDashed': 'service:something-that-is-dashed' }, namespace: { modulePrefix: 'foo-bar' } })
 
     define('foo-bar/services/something-that-is-dashed', [], function(){
       assert.ok(true, "service was invoked properly");

--- a/tests/unit/strict-resolver/basic-test.js
+++ b/tests/unit/strict-resolver/basic-test.js
@@ -58,22 +58,6 @@ module('Unit | strict-resolver | basic', function(hooks) {
     })
   });
 
-  test('can lookup via legacyMappings for migrating off of ember-resolver/classic', function(assert){
-    assert.expect(2);
-
-    setupResolver({ legacyMappings: { 'service:somethingThatIsDashed': 'service:something-that-is-dashed' }, namespace: { modulePrefix: 'foo-bar' } })
-
-    define('foo-bar/services/something-that-is-dashed', [], function(){
-      assert.ok(true, "service was invoked properly");
-
-      return {};
-    });
-
-    var service = resolver.resolve('service:somethingThatIsDashed');
-
-    assert.ok(service, 'service was returned');
-  });
-
   test('can lookup something', function(assert){
     assert.expect(2);
 

--- a/tests/unit/strict-resolver/basic-test.js
+++ b/tests/unit/strict-resolver/basic-test.js
@@ -58,7 +58,23 @@ module('Unit | strict-resolver | basic', function(hooks) {
     })
   });
 
-  test("can lookup something", function(assert){
+  test('can lookup via failSet for migrating off of ember-resolver/classic', function(assert){
+    assert.expect(2);
+
+    setupResolver({ failSet: { 'service:somethingThatIsDashed': 'service:something-that-is-dashed' }, namespace: { modulePrefix: 'foo-bar' } })
+
+    define('foo-bar/services/something-that-is-dashed', [], function(){
+      assert.ok(true, "service was invoked properly");
+
+      return {};
+    });
+
+    var service = resolver.resolve('service:somethingThatIsDashed');
+
+    assert.ok(service, 'service was returned');
+  });
+
+  test('can lookup something', function(assert){
     assert.expect(2);
 
     define('foo-bar/adapters/post', [], function(){


### PR DESCRIPTION
*Why?*

For applications with multiple dependencies migrating from the classic resolver to the strict resolver requires updating multiple dependencies to support it. As a part of that effort, it would be great to migrate completely to ember-resolver/strict with a set of expected failure cases. This will allow applications to not introduce new errors as they remove failSet mappings.

