### PR TITLE
[chore] bring down upstream parsing logic, ensures that we don't assert against types that are not required to be dasherized and also put that behind a debug flag

### DIFF
--- a/addon/index.js
+++ b/addon/index.js
@@ -1,7 +1,8 @@
 /* globals requirejs */
 
-import { assert } from '@ember/debug';
+import { warn } from '@ember/debug';
 import { dasherize } from '@ember/string';
+import { DEBUG } from '@glimmer/env';
 
 import require from 'require';
 
@@ -20,37 +21,72 @@ export default class Resolver {
     return moduleName in (requirejs.entries || requirejs._eak_seen);
   }
 
-  moduleNameForFullName(fullName) {
-    assert(`Attempted to lookup "${fullName}". Use "${dasherize(fullName)}" instead.`, !fullName.match(/[a-z]+[A-Z]+/));
+  parseFullName(fullName) {
+    let prefix, type, name;
 
-    let prefix, type, name, moduleName;
+    let fullNameParts = fullName.split('@');
 
-    const fullNameParts = fullName.split('@');
+    if (fullNameParts.length === 3) {
+      if (fullNameParts[0].length === 0) {
+        // leading scoped namespace: `@scope/pkg@type:name`
+        prefix = `@${fullNameParts[1]}`;
+        let prefixParts = fullNameParts[2].split(':');
+        type = prefixParts[0];
+        name = prefixParts[1];
+      } else {
+        // interweaved scoped namespace: `type:@scope/pkg@name`
+        prefix = `@${fullNameParts[1]}`;
+        type = fullNameParts[0].slice(0, -1);
+        name = fullNameParts[2];
+      }
 
-    if (fullNameParts.length === 2) {
-      const prefixParts = fullNameParts[0].split(':');
+      if (type === 'template:components') {
+        name = `components/${name}`;
+        type = 'template';
+      }
+    } else if (fullNameParts.length === 2) {
+      let prefixParts = fullNameParts[0].split(':');
 
       if (prefixParts.length === 2) {
-        prefix = prefixParts[1];
-        type = prefixParts[0];
-        name = fullNameParts[1];
+        if (prefixParts[1].length === 0) {
+          type = prefixParts[0];
+          name = `@${fullNameParts[1]}`;
+        } else {
+          prefix = prefixParts[1];
+          type = prefixParts[0];
+          name = fullNameParts[1];
+        }
       } else {
-        const typeNameParts = fullNameParts[1].split(':');
+        let nameParts = fullNameParts[1].split(':');
+
         prefix = fullNameParts[0];
-        type = typeNameParts[0];
-        name = typeNameParts[1];
+        type = nameParts[0];
+        name = nameParts[1];
+      }
+
+      if (type === 'template' && prefix.lastIndexOf('components/', 0) === 0) {
+        name = `components/${name}`;
+        prefix = prefix.slice(11);
       }
     } else {
-      const typeNameParts = fullName.split(':');
+      fullNameParts = fullName.split(':');
+
       prefix = this.namespace.modulePrefix;
-      type = typeNameParts[0];
-      name = typeNameParts[1];
+      type = fullNameParts[0];
+      name = fullNameParts[1];
     }
 
-    if (type === 'template' && prefix.lastIndexOf('components/', 0) === 0) {
-      name = `components/${name}`;
-      prefix = prefix.slice(11);
+    return {
+      prefix,
+      type,
+      name
     }
+  }
+
+  moduleNameForFullName(fullName) {
+    let moduleName;
+
+    const { prefix, type, name } = this.parseFullName(fullName);
 
     if (name === 'main') {
       moduleName = `${prefix}/${type}`;
@@ -78,6 +114,14 @@ export default class Resolver {
   }
 
   normalize(fullName) {
+    if(DEBUG) {
+      const { type } = this.parseFullName(fullName);
+
+      if(['service'].includes(type)) {
+        warn(`Attempted to lookup "${fullName}". Use "${dasherize(fullName)}" instead.`, !fullName.match(/[a-z]+[A-Z]+/), { id: 'ember-strict-resolver.camelcase-names' });
+      }
+    }
+
     return fullName;
   }
 }


### PR DESCRIPTION
# Motivation

Talking with @rwjblue there were a lot of improvements in the parsing logic upstream and bringing that into strict resolver will be beneficial for support. Also asserting against all types is causing #28 where as helpers, components, templates have no necessity to be camel cased. 

Fixes #28 