### PR TITLE
[bug] ensure that require key exists before trying to retrieve from the require registry

### DIFF
--- a/addon/index.js
+++ b/addon/index.js
@@ -1,3 +1,5 @@
+/* globals requirejs */
+
 import { assert } from '@ember/debug';
 import { dasherize } from '@ember/string';
 
@@ -12,6 +14,10 @@ export default class Resolver {
 
   static create(args) {
     return new this(args);
+  }
+
+  has(moduleName) {
+    return moduleName in (requirejs.entries || requirejs._eak_seen);
   }
 
   moduleNameForFullName(fullName) {
@@ -64,7 +70,7 @@ export default class Resolver {
   resolve(fullName) {
     const moduleName = this.moduleNameForFullName(fullName);
 
-    if (require.has(moduleName)) {
+    if (this.has(moduleName)) {
       // hit
       return require(moduleName)['default'];
     }

--- a/tests/unit/strict-resolver/basic-test.js
+++ b/tests/unit/strict-resolver/basic-test.js
@@ -222,4 +222,14 @@ module('Unit | strict-resolver | basic', function(hooks) {
 
     assert.equal(template, expected, 'default export was returned');
   });
+
+  test("does not lookup index when top level component is specified (route:view)", function(assert) {
+    assert.expect(1);
+
+    define('foo-bar/routes/view/index', [], function(){
+      assert.ok(false, 'should not have been required');
+    });
+
+    assert.ok(!resolver.resolve('route:view'), 'route was not returned');
+  });
 });


### PR DESCRIPTION
# Motivation

route:view would resolve to `{namespace}/routes/view/index`  and now it resolves to  `{namespace}/routes/view` 

fixes #30 