### PR TITLE
Declare resolver is module-based

### DIFF
--- a/addon/index.js
+++ b/addon/index.js
@@ -11,6 +11,9 @@ export default class Resolver {
     if (attrs) {
       this.namespace = attrs.namespace;
     }
+    // secret handshake with router to ensure substates are enabled
+    // see https://github.com/emberjs/ember.js/blob/a429dc327ee6ef97d948a83e727886c75c6fe043/packages/%40ember/-internals/routing/lib/system/router.ts#L344
+    this.moduleBasedResolver = true;
   }
 
   static create(args) {

--- a/tests/unit/strict-resolver/basic-test.js
+++ b/tests/unit/strict-resolver/basic-test.js
@@ -39,8 +39,15 @@ module('Unit | strict-resolver | basic', function(hooks) {
     Resolver.create();
   });
 
-  test('moduleNameForFullName', function(assert) {
+  test('is module based', function (assert) {
+    assert.strictEqual(
+      resolver.moduleBasedResolver,
+      true,
+      'resolver declares itself module-based to enable router features'
+    );
+  });
 
+  test('moduleNameForFullName', function (assert) {
     const testPairs = [
       ['route:application', 'foo-bar/routes/application'],
       ['route:application/index', 'foo-bar/routes/application/index'],


### PR DESCRIPTION
resolver.moduleBasedResolver must be set for the ember router to enable loading substates, so set that property in the constructor.