### PR TITLE
Handle non-default exports with embroider

### DIFF
--- a/addon/index.js
+++ b/addon/index.js
@@ -111,7 +111,7 @@ export default class Resolver {
 
     if (this.has(moduleName)) {
       // hit
-      return require(moduleName)['default'];
+      return this._requireDefaultExport(moduleName);
     }
     // miss
   }
@@ -126,5 +126,15 @@ export default class Resolver {
     }
 
     return fullName;
+  }
+
+  _requireDefaultExport(normalizedModuleName) {
+    const module = require(normalizedModuleName);
+
+    if (module && module['default']) {
+      return module['default'];
+    }
+
+    return module;
   }
 }


### PR DESCRIPTION
For whatever reason, when running this with embroider & `staticHelpers: true`, helpers are compiled slightly different. They have no `default` export, but instead the module from `require(name)` contains the helper directly.

This fixes the resolver by adding the same check as exists in [ember-resolver](https://github.com/ember-cli/ember-resolver/blob/87eeacdc8c76e9e8b5f98d21244d4e70466539a0/addon/resolvers/classic/index.js#L468) to just return the module directly in this case.

I have tested this in my app and it worked fine there.

Fixes https://github.com/stefanpenner/ember-strict-resolver/issues/44